### PR TITLE
Recode and on_tab_change event added

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,64 +1,162 @@
-import os
+from datetime import datetime
+from os import path, remove
+
 from cudatext import *
-import cudatext_cmd as cmds
 
-fn_config = os.path.join(app_path(APP_DIR_SETTINGS), 'cuda_auto_save.ini')
+plugin_name = __name__
+fn_config = path.join(app_path(APP_DIR_SETTINGS), 'cuda_auto_save.ini')
 
-opt_save_interval = 30
+opt_save_interval_seconds = 30
+opt_save_max_mb_size_file = 5
 opt_save_onclose = False
 opt_save_ondeact = False
+opt_save_ontabchange = False
+
+
+# Simple implementation of logger.
+class Log:
+    info_ = True
+    # Change conditional to True to log messages in a Debug process
+    debug_ = False
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def info(s):
+        if Log.info_:
+            print(datetime.now().strftime("%H:%M:%S,%f") + ' [INFO] ' +
+                  plugin_name + ' - ' + str(s))
+
+    @staticmethod
+    def debug(s):
+        if Log.debug_:
+            print(datetime.now().strftime("%H:%M:%S,%f") + ' [DEBUG] ' +
+                  plugin_name + ' - ' + str(s))
+
 
 def bool_to_str(v): return '1' if v else '0'
-def str_to_bool(s): return s=='1'
+
+
+def str_to_bool(s): return s == '1'
+
+
+def get_log_file_size(fn_KB_size):
+    msg = 'Max auto-saving file size: ' + \
+          str(opt_save_max_mb_size_file * 1024) + \
+          ' KBs / Current file size: ' + str(fn_KB_size) + ' KBs'
+    return msg
+
 
 def save_all(msg):
 
     for h in ed_handles():
         e = Editor(h)
-        fn = e.get_filename()
-        if fn and e.get_prop(PROP_MODIFIED, ''):
+        save_one(e, 'Saving file (' + msg + '): ')
+
+
+def save_one(e, msg):
+    fn = e.get_filename()
+
+    if not fn: return
+
+    Log.debug('Processing file: ' + fn)
+    if e.get_prop(PROP_MODIFIED, ''):
+        fn_KB_size = path.getsize(fn) // 1024
+        Log.debug(get_log_file_size(fn_KB_size))
+
+        if opt_save_max_mb_size_file == 0 or fn_KB_size // 1024 <= opt_save_max_mb_size_file:
             e.save()
-            print('Auto-saved ('+msg+'):', fn)
+            Log.info(msg + fn)
+
 
 def timer_tick(tag='', info=''):
+    save_all('By timer')
 
-    save_all('by timer')
+
+def recreate_events(inc_event='', setup_timer=1):
+    global opt_save_interval_seconds
+    global opt_save_max_mb_size_file
+    global opt_save_onclose
+    global opt_save_ondeact
+    global opt_save_ontabchange
+
+    # Read settings if config file exists.
+    if path.isfile(fn_config):
+        opt_save_interval_seconds = int(ini_read(fn_config, 'op', 'save_interval_seconds', str(opt_save_interval_seconds)))
+        opt_save_max_mb_size_file = int(ini_read(fn_config, 'op', 'save_max_MB_file_size', str(opt_save_max_mb_size_file)))
+        opt_save_onclose = str_to_bool(ini_read(fn_config, 'op', 'save_before_closing_tab', bool_to_str(opt_save_onclose)))
+        opt_save_ondeact = str_to_bool(ini_read(fn_config, 'op', 'save_on_deactivate', bool_to_str(opt_save_ondeact)))
+        opt_save_ontabchange = str_to_bool(ini_read(fn_config, 'op', 'save_on_tab_change', bool_to_str(opt_save_ontabchange)))
+
+    events = []
+    if inc_event: events.append(inc_event)
+    # on_tab_change event is called before on_close_pre event
+    if not opt_save_ontabchange and opt_save_onclose: events.append('on_close_pre')
+    if opt_save_ondeact: events.append('on_app_deactivate')
+    if opt_save_ontabchange: events.append('on_tab_change')
+
+    Log.info('Recreating events: ' + ','.join(events))
+    app_proc(PROC_SET_EVENTS, plugin_name + ';' + ','.join(events) + ';;')
+
+    if setup_timer != 1: return
+
+    if opt_save_interval_seconds > 0:
+        Log.info('Turning on timer_tick function.')
+        timer_proc(TIMER_START, 'module=cuda_auto_save;func=timer_tick;',
+                   opt_save_interval_seconds*1000)
+    else:
+        Log.info('Turning off timer_tick function.')
+        timer_proc(TIMER_STOP, 'module=cuda_auto_save;func=timer_tick;', 0)
+
 
 class Command:
 
     def __init__(self):
-
-        global opt_save_interval
-        global opt_save_onclose
-        global opt_save_ondeact
-        opt_save_interval = int(ini_read(fn_config, 'op', 'save_interval', str(opt_save_interval)))
-        opt_save_onclose = str_to_bool(ini_read(fn_config, 'op', 'save_before_closing_tab', bool_to_str(opt_save_onclose)))
-        opt_save_ondeact = str_to_bool(ini_read(fn_config, 'op', 'on_deactivate', bool_to_str(opt_save_ondeact)))
+        recreate_events()
 
     def on_start(self, ed_self):
-
-        if opt_save_interval>0:
-            timer_proc(TIMER_START, 'module=cuda_auto_save;func=timer_tick;', opt_save_interval*1000)
+        # Created only to initialize this plugin.
+        Log.debug('on_start event')
+        pass
 
     def config(self):
+        # Wait for config file closing in order do not need to restart CudaText
+        # to get new option values.
+        recreate_events(inc_event='on_close', setup_timer=0)
 
-        ini_write(fn_config, 'op', 'save_interval', str(opt_save_interval))
+        # Delete file in case there are more settings of previous version
+        if path.isfile(fn_config): remove(fn_config)
+
+        # Add some comments to provide help guidelines in file config.
+        with open(fn_config, "a") as f:
+            f.write('; save_interval_seconds=0 to deactivate.\n')
+            f.write('; save_max_MB_file_size=0 to deactivate.\n')
+
+        ini_write(fn_config, 'op', 'save_interval_seconds', str(opt_save_interval_seconds))
+        ini_write(fn_config, 'op', 'save_max_MB_file_size', str(opt_save_max_mb_size_file))
         ini_write(fn_config, 'op', 'save_before_closing_tab', bool_to_str(opt_save_onclose))
-        ini_write(fn_config, 'op', 'on_deactivate', bool_to_str(opt_save_ondeact))
+        ini_write(fn_config, 'op', 'save_on_deactivate', bool_to_str(opt_save_ondeact))
+        ini_write(fn_config, 'op', 'save_on_tab_change', bool_to_str(opt_save_ontabchange))
         file_open(fn_config)
 
     def on_close_pre(self, ed_self):
-
-        if not opt_save_onclose:
-            return
-        fn = ed_self.get_filename()
-        if not fn: return
-        if ed_self.get_prop(PROP_MODIFIED, ''):
-            ed_self.save()
-            print('Auto-saved (file closes):', fn)
+        Log.debug('on_close_pre event')
+        save_one(ed_self, 'Auto-saved (File closes): ')
 
     def on_app_deactivate(self, ed_self):
+        Log.debug('on_app_deactivate event')
+        save_all('App deactivated')
 
-        if not opt_save_ondeact:
-            return
-        save_all('app deactivated')
+    def on_tab_change(self, ed_self):
+        Log.debug('on_tab_change event')
+        save_all('Tab change')
+
+    def on_close(self, ed_self):
+        # Used only to catch when Config file is modified and saved
+        Log.debug('on_close event')
+
+        fn = ed_self.get_filename()
+        if not fn: return
+
+        if fn == fn_config: recreate_events()

--- a/install.inf
+++ b/install.inf
@@ -1,6 +1,6 @@
 [info]
 title=Auto Save
-desc=Saves modified files automatically: before file closing (by option, default is off), by timer (default interval 30sec), on application deactivation
+desc=Saves modified files automatically: before file closing (by option, default is off), by timer (default interval 30sec), on application deactivation and changing active tab (by option, default is off)
 type=cudatext-plugin
 subdir=cuda_auto_save
 homepage=https://github.com/CudaText-addons/cuda_auto_save
@@ -8,7 +8,7 @@ api=1.0.351
 
 [item1]
 section=events
-events=on_start,on_close_pre,on_app_deactivate
+events=on_start
 
 [item100]
 section=commands

--- a/readme/history.txt
+++ b/readme/history.txt
@@ -1,6 +1,13 @@
+2021.04.07 (patch by @JairoMartinezA)
++ added option "save_on_tab_change" (0/1) to auto-save file when user switches
+  between tabs
++ added option "save_max_MB_file_size" (0+) to control the max file size in MB
+  where the plugin can proceed with auto saving.
+* reworked code
 
 2020.10.04
-+ added option "on_deactivate" (0/1) to auto-save file when application looses focus; requires CudaText 1.114
++ added option "on_deactivate" (0/1) to auto-save file when application looses
+  focus; requires CudaText 1.114
 
 2018.06.09
-initial
++ initial

--- a/readme/readme.txt
+++ b/readme/readme.txt
@@ -1,11 +1,20 @@
-plugin for CudaText.
-automatically saves modified files. currently: only named tabs (ignores untitled tabs).
-it has config file with few options, call it by menu "Options / Settings-plugins / Auto Save".
+Plugin for CudaText.
 
-options:
-- "save_interval" (number, default: 30)
-  interval of timer which auto-saves files, in seconds. 
+"Auto Save" automatically saves modified files, it works only with named tabs
+ignoring untitled tabs.
+
+Plugin options
+--------------
+
+You can access to options using "Options / Settings-plugins / Auto Save / Config"
+
+- "save_interval_seconds" (number, default: 30)
+  interval of timer which auto-saves files, in seconds.
   to disable auto-saving by timer, set to 0.
+
+- "save_max_MB_file_size" (number, default: 5)
+  max size in MB where plugin will proceed with auto-saving.
+  to auto-save regardless the file size, set to 0.
 
 - "save_before_closing_tab" (0 or 1, default: 0)
   enables to auto-save file just before its closing (without any confirmation).
@@ -14,5 +23,13 @@ options:
   enables to auto-save when CudaText looses focus.
   requires CudaText 1.114+.
 
-author: Alexey Torgashin (CudaText)
-license: MIT
+- "save_on_tab_change" (0 or 1, default: 0)
+  enables to auto-save file after changing active tab.
+
+About
+-----
+
+Author:       Alexey Torgashin (CudaText)
+Contributors:
+              @JairoMartinezA (at GitHub)
+License:      MIT


### PR DESCRIPTION
Hi Alex,

If you want to validate the next changes:

* The code was reworked.
* About the events, I changed to use now `app_proc(PROC_SET_EVENTS` instead to declare it in **install.inf** in order to do not validate each event inside code; I think it is better in performance.
* Was added default login python module, set currently to INFO level, the developer can change to DEBUG in order to see log verbosity.
* Using a trick with `app_proc` and `on_close` event is not necessary to restart CudaText to take the new values when the user changes the plugin config.
* Added an option to save when the user change between the active tab.
* Added an option to controle what files can proceed with auto-saving taking notice of a maximum file size.